### PR TITLE
Try Flux model

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,17 @@ authors = ["Eric P. Hanson"]
 version = "1.0.0-DEV"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
+StrideArraysCore = "7792a7ef-975c-4747-a70f-980b88e8d1da"
 
 [compat]
 julia = "1.9"
 
 [extras]
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Flux", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,8 @@ julia = "1.9"
 
 [extras]
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Flux", "Test"]
+test = ["Flux", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,10 @@ ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
 StrideArraysCore = "7792a7ef-975c-4747-a70f-980b88e8d1da"
 
 [compat]
+Adapt = "3"
+Bumper = "0.3"
+ScopedValues = "1"
+StrideArraysCore = "0.5"
 julia = "1.9"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AllocArrays"
 uuid = "5c00bae2-1499-4716-9206-27f63fd08a44"
 authors = ["Eric P. Hanson"]
-version = "1.0.0-DEV"
+version = "1.0.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -11,15 +11,17 @@ StrideArraysCore = "7792a7ef-975c-4747-a70f-980b88e8d1da"
 
 [compat]
 Adapt = "3"
+Aqua = "0.7"
 Bumper = "0.3"
 ScopedValues = "1"
 StrideArraysCore = "0.5"
 julia = "1.9"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Flux", "Random", "Test"]
+test = ["Aqua", "Flux", "Random", "Test"]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ a = AllocArray(arr);
 We can see we brought allocations down from 2.289 MiB to 800 bytes.
 
 For a less-toy example, in `test/flux.jl` we test inference over a Flux model:
+
 ```julia
 # Baseline: Array
 infer!(predictions, model, data): 1.824578 seconds (59.50 k allocations: 2.841 GiB, 10.10% gc time)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ a = AllocArray(arr);
 ```
 We can see we brought allocations down from 2.289 MiB to 800 bytes.
 
-For a less-toy example, in `test/flux.jl` we test inferencne over a Flux model:
+For a less-toy example, in `test/flux.jl` we test inference over a Flux model:
 ```julia
 # Baseline: Array
 infer!(predictions, model, data): 2.053936 seconds (59.49 k allocations: 2.841 GiB, 11.71% gc time)

--- a/README.md
+++ b/README.md
@@ -46,3 +46,16 @@ a = AllocArray(arr);
 @time bumper_reduction(a) #  0.000528 seconds (25 allocations: 800 bytes)
 ```
 We can see we brought allocations down from 2.289 MiB to 800 bytes.
+
+For a less-toy example, in `test/flux.jl` we test inferencne over a Flux model:
+```julia
+# Baseline: Array
+infer!(predictions, model, data): 2.053936 seconds (59.49 k allocations: 2.841 GiB, 11.71% gc time)
+# Baseline: StrideArray
+stride_data = StrideArray.(data)
+infer!(predictions, model, stride_data): 1.960467 seconds (59.49 k allocations: 2.841 GiB, 11.92% gc time)
+# Using AllocArray:
+alloc_data = AllocArray.(data)
+infer!(predictions, model, alloc_data): 1.630521 seconds (118.34 k allocations: 28.843 MiB)
+```
+We can see in this example, we got ~100x less allocation, and slight runtime improvement.

--- a/src/AllocArray.jl
+++ b/src/AllocArray.jl
@@ -12,9 +12,6 @@ but dispatches `similar` to special allocation methods.
 """
 struct AllocArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
     arr::A
-    # function AllocArray(arr)
-    # return adapt(AllocArray, arr)
-    # end
 end
 
 Base.parent(a::AllocArray) = a.arr
@@ -68,7 +65,6 @@ function Base.unsafe_convert(::Type{Ptr{T}}, a::AllocArray) where {T}
 end
 
 Base.elsize(::Type{<:AllocArray{T,N,Arr}}) where {T,N,Arr} = Base.elsize(Arr)
-# Base.elsize(a::AllocArray) = Base.elsize(parent(a))
 
 # Piracy - shouldn't this be defined on the type level in StrideArraysCore?
 @inline Base.elsize(::Type{<:StrideArraysCore.AbstractStrideArray{T}}) where {T} = sizeof(T)

--- a/src/AllocArray.jl
+++ b/src/AllocArray.jl
@@ -70,3 +70,11 @@ Base.elsize(::Type{<:AllocArray{T,N,Arr}}) where {T,N,Arr} = Base.elsize(Arr)
 @inline Base.elsize(::Type{<:StrideArraysCore.AbstractStrideArray{T}}) where {T} = sizeof(T)
 
 Base.strides(a::AllocArray) = strides(parent(a))
+
+#####
+##### Other
+#####
+
+# Avoid reshaped arrays; saves quite a bit of time
+Base.reshape(a::AllocArray, args::Int...) = AllocArray(reshape(parent(a), args...))
+Base.reshape(a::AllocArray, dims::Dims) = AllocArray(reshape(parent(a), dims))

--- a/src/AllocArray.jl
+++ b/src/AllocArray.jl
@@ -16,11 +16,13 @@ end
 
 @inline Base.parent(a::AllocArray) = getfield(a, :arr)
 
-@inline Base.@propagate_inbounds function Base.setindex!(a::AllocArray{T,N}, value, I::Vararg{Int,N}) where {T,N}
+@inline Base.@propagate_inbounds function Base.setindex!(a::AllocArray{T,N}, value,
+                                                         I::Vararg{Int,N}) where {T,N}
     return setindex!(getfield(a, :arr), value, I...)
 end
 
-@inline Base.@propagate_inbounds function Base.getindex(a::AllocArray{T,N}, I::Vararg{Int,N}) where {T,N}
+@inline Base.@propagate_inbounds function Base.getindex(a::AllocArray{T,N},
+                                                        I::Vararg{Int,N}) where {T,N}
     return getindex(getfield(a, :arr), I...)
 end
 Base.size(a::AllocArray) = size(getfield(a, :arr))

--- a/src/AllocArray.jl
+++ b/src/AllocArray.jl
@@ -12,13 +12,37 @@ but dispatches `similar` to special allocation methods.
 """
 struct AllocArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
     arr::A
+    # function AllocArray(arr)
+    # return adapt(AllocArray, arr)
+    # end
 end
 
+Base.parent(a::AllocArray) = a.arr
+
 function Base.setindex!(a::AllocArray{T,N}, value, I::Vararg{Int,N}) where {T,N}
-    return setindex!(a.arr, value, I...)
+    return setindex!(parent(a), value, I...)
 end
-Base.getindex(a::AllocArray{T,N}, I::Vararg{Int,N}) where {T,N} = getindex(a.arr, I...)
-Base.size(a::AllocArray) = size(a.arr)
+Base.getindex(a::AllocArray{T,N}, I::Vararg{Int,N}) where {T,N} = getindex(parent(a), I...)
+Base.size(a::AllocArray) = size(parent(a))
+
+# used only by broadcasting?
+function Base.similar(::Type{AllocArray{T,N,Arr}}, dims::Dims) where {T,N,Arr}
+    # TODO- I think this shouldn't be `Array{T}`,
+    # but if we do `Arr`, then we are passing dimensionality info we don't necessarily
+    # want to respect here. We want some `generic_type(Arr)` where is `Array{T}`
+    # for `Vector` etc, but would be `CuArray` for `CuVector` etc.
+    inner = alloc_similar(CURRENT_ALLOCATOR[], Array{T}, dims)
+    return AllocArray(inner)
+end
+
+function Base.similar(A::AllocArray, ::Type{T}, dims::Dims) where {T}
+    inner = alloc_similar(CURRENT_ALLOCATOR[], parent(A), T, dims)
+    return AllocArray(inner)
+end
+
+#####
+##### Broadcasting
+#####
 
 function Base.BroadcastStyle(::Type{AllocArray{T,N,Arr}}) where {T,N,Arr}
     return Broadcast.ArrayStyle{AllocArray{T,N,Arr}}()
@@ -29,12 +53,24 @@ function Base.similar(bc::Broadcasted{ArrayStyle{AllocArray{T,N,Arr}}},
     return similar(AllocArray{T,N,Arr}, axes(bc))
 end
 
-function Base.similar(::Type{AllocArray{T,N,Arr}}, dims::Dims) where {T,N,Arr}
-    inner = alloc_similar(CURRENT_ALLOCATOR[], Arr, dims)
-    return AllocArray{T,N,Arr}(inner)
+#####
+##### Adapt.jl
+#####
+
+Adapt.adapt_structure(to, x::AllocArray) = AllocArray(adapt(to, parent(x)))
+
+#####
+##### StridedArray interface
+#####
+
+function Base.unsafe_convert(::Type{Ptr{T}}, a::AllocArray) where {T}
+    return Base.unsafe_convert(Ptr{T}, parent(a))
 end
 
-function Base.similar(A::AllocArray, ::Type{T}, dims::Dims) where {T}
-    inner = alloc_similar(CURRENT_ALLOCATOR[], A.arr, T, dims)
-    return AllocArray(inner)
-end
+Base.elsize(::Type{<:AllocArray{T,N,Arr}}) where {T,N,Arr} = Base.elsize(Arr)
+# Base.elsize(a::AllocArray) = Base.elsize(parent(a))
+
+# Piracy - shouldn't this be defined on the type level in StrideArraysCore?
+@inline Base.elsize(::Type{<:StrideArraysCore.AbstractStrideArray{T}}) where {T} = sizeof(T)
+
+Base.strides(a::AllocArray) = strides(parent(a))

--- a/src/AllocArrays.jl
+++ b/src/AllocArrays.jl
@@ -11,7 +11,14 @@ export AllocArray, with_bumper
 
 include("alloc_interface.jl")
 
-const CURRENT_ALLOCATOR = ScopedValue{Allocator}(DEFAULT_ALLOCATOR)
+# make more type stable...
+# const CURRENT_ALLOCATOR = ScopedValue{Allocator}(DEFAULT_ALLOCATOR)
+const CURRENT_ALLOCATOR = Ref{BumperAllocator{Vector{UInt8}}}()
+
+function __init__()
+    CURRENT_ALLOCATOR[] = BumperAllocator(Bumper.default_buffer())
+    return nothing
+end
 
 include("AllocArray.jl")
 

--- a/src/AllocArrays.jl
+++ b/src/AllocArrays.jl
@@ -1,6 +1,6 @@
 module AllocArrays
 
-using ScopedValues: ScopedValue, scoped
+using ScopedValues: ScopedValue, with
 using Bumper
 using Adapt
 

--- a/src/AllocArrays.jl
+++ b/src/AllocArrays.jl
@@ -10,9 +10,8 @@ using StrideArraysCore: StrideArraysCore
 export AllocArray, with_bumper
 
 include("alloc_interface.jl")
+include("AllocArray.jl")
 
 const CURRENT_ALLOCATOR = ScopedValue{Allocator}(DEFAULT_ALLOCATOR)
-
-include("AllocArray.jl")
 
 end # module

--- a/src/AllocArrays.jl
+++ b/src/AllocArrays.jl
@@ -7,7 +7,7 @@ using Adapt
 # for some piracy
 using StrideArraysCore: StrideArraysCore
 
-export AllocArray, with_bumper
+export AllocArray, with_bumper, with_locked_bumper
 
 include("alloc_interface.jl")
 include("AllocArray.jl")

--- a/src/AllocArrays.jl
+++ b/src/AllocArrays.jl
@@ -11,14 +11,7 @@ export AllocArray, with_bumper
 
 include("alloc_interface.jl")
 
-# make more type stable...
-# const CURRENT_ALLOCATOR = ScopedValue{Allocator}(DEFAULT_ALLOCATOR)
-const CURRENT_ALLOCATOR = Ref{BumperAllocator{Vector{UInt8}}}()
-
-function __init__()
-    CURRENT_ALLOCATOR[] = BumperAllocator(Bumper.default_buffer())
-    return nothing
-end
+const CURRENT_ALLOCATOR = ScopedValue{Allocator}(DEFAULT_ALLOCATOR)
 
 include("AllocArray.jl")
 

--- a/src/AllocArrays.jl
+++ b/src/AllocArrays.jl
@@ -2,6 +2,10 @@ module AllocArrays
 
 using ScopedValues: ScopedValue, scoped
 using Bumper
+using Adapt
+
+# for some piracy
+using StrideArraysCore: StrideArraysCore
 
 export AllocArray, with_bumper
 

--- a/src/alloc_interface.jl
+++ b/src/alloc_interface.jl
@@ -48,14 +48,6 @@ function alloc_similar(B::BumperAllocator, ::Type{Arr}, dims::Dims) where {Arr}
     return Bumper.alloc(eltype(Arr), B.buf, dims...)
 end
 
-function with_bumper(f, buf)
-    old = CURRENT_ALLOCATOR[]
-    CURRENT_ALLOCATOR[] = BumperAllocator(buf)
-    try
-        return f()
-    finally
-        CURRENT_ALLOCATOR[] = old
-    end
+function with_bumper(f, buf...)
+    return scoped(f, CURRENT_ALLOCATOR => BumperAllocator(buf...))
 end
-
-with_bumper(f) = f()

--- a/src/alloc_interface.jl
+++ b/src/alloc_interface.jl
@@ -49,5 +49,5 @@ function alloc_similar(B::BumperAllocator, ::Type{Arr}, dims::Dims) where {Arr}
 end
 
 function with_bumper(f, buf...)
-    return scoped(f, CURRENT_ALLOCATOR => BumperAllocator(buf...))
+    return with(f, CURRENT_ALLOCATOR => BumperAllocator(buf...))
 end

--- a/test/flux.jl
+++ b/test/flux.jl
@@ -95,7 +95,7 @@ end
     model = DigitsModel()
 
     # Setup some fake data
-    N = 1_000
+    N = 10_000
     data_arr = rand(Float32, 28, 28, N)
 
     # Partition into batches of size 32

--- a/test/flux.jl
+++ b/test/flux.jl
@@ -80,6 +80,7 @@ end
 (m::DigitsModel)(x) = m.chain(x)
 
 function infer!(predictions, model, data)
+    # Is this safe? NNlib multithreads some of the layers, so not sure.
     buf = Bumper.default_buffer()
     with_bumper(buf) do
         for (idx, x) in enumerate(data)

--- a/test/flux.jl
+++ b/test/flux.jl
@@ -3,10 +3,10 @@ using Flux, Random
 model = Chain(Dense(1 => 23, tanh), Dense(23 => 1; bias=false), only)
 
 data = [[x] for x in -2:0.001f0:2];
-@time sum(model, data)
+@showtime sum(model, data)
 
 alloc_data = AllocArray.(data);
-@time sum(model, alloc_data)
+@showtime sum(model, alloc_data)
 
 function bumper_run(model, data)
     buf = Bumper.default_buffer()
@@ -17,8 +17,8 @@ function bumper_run(model, data)
     end
 end
 
-@time bumper_run(model, alloc_data)
-@time bumper_run(model, alloc_data)
+@showtime bumper_run(model, alloc_data)
+@showtime bumper_run(model, alloc_data)
 
 #####
 ##### More complicated model
@@ -105,8 +105,14 @@ n_class = 10
 predictions = [Matrix{Float32}(undef, n_class, size(x, 4)) for x in data];
 
 alloc_data = AllocArray.(data)
-@time infer!(predictions, model, data);
-@time infer!(predictions, model, data);
 
-@time infer!(predictions, model, alloc_data);
-@time infer!(predictions, model, alloc_data);
+@showtime infer!(predictions, model, data);
+@showtime infer!(predictions, model, data);
+
+@showtime infer!(predictions, model, alloc_data);
+@showtime infer!(predictions, model, alloc_data);
+
+
+stride_data = StrideArray.(data)
+@showtime infer!(predictions, model, stride_data);
+@showtime infer!(predictions, model, stride_data);

--- a/test/flux.jl
+++ b/test/flux.jl
@@ -1,4 +1,4 @@
-using Flux, Random
+using Flux, Random, StrideArraysCore
 
 model = Chain(Dense(1 => 23, tanh), Dense(23 => 1; bias=false), only)
 
@@ -111,7 +111,6 @@ alloc_data = AllocArray.(data)
 
 @showtime infer!(predictions, model, alloc_data);
 @showtime infer!(predictions, model, alloc_data);
-
 
 stride_data = StrideArray.(data)
 @showtime infer!(predictions, model, stride_data);

--- a/test/flux.jl
+++ b/test/flux.jl
@@ -1,0 +1,112 @@
+using Flux
+
+model = Chain(Dense(1 => 23, tanh), Dense(23 => 1; bias=false), only)
+
+data = [[x] for x in -2:0.001f0:2]
+@time sum(model, data)
+
+alloc_data = AllocArray.(data)
+@time sum(model, alloc_data)
+
+function bumper_run(model, data)
+    with_bumper() do
+        @no_escape begin
+            sum(model, data)
+        end
+    end
+end
+
+@time bumper_run(model, alloc_data)
+@time bumper_run(model, alloc_data)
+
+#####
+##### More complicated model
+#####
+
+# from https://github.com/beacon-biosignals/LegolasFlux.jl/blob/27acd1bd20e5b335794fbf4c5cade46cc75c54c6/examples/digits.jl
+
+# This should store all the information needed
+# to construct the model.
+Base.@kwdef struct DigitsConfigV1
+    seed::Int = 5
+    dropout_rate::Float32 = 0.0f1
+end
+
+# Here's our model object itself, just a `DigitsConfig` and
+# a `chain`. We keep the config around so it's easy to save out
+# later.
+struct DigitsModel
+    chain::Chain
+    config::DigitsConfigV1
+end
+
+# Ensure Flux can recurse into our model to find params etc
+Flux.@functor DigitsModel (chain,)
+
+# Construct the actual model from a config object. This is the only
+# constructor that should be used, to ensure the model is created just
+# from the config object alone.
+function DigitsModel(config::DigitsConfigV1=DigitsConfigV1())
+    dropout_rate = config.dropout_rate
+    Random.seed!(config.seed)
+    D = Dense(10, 10)
+    chain = Chain(Dropout(dropout_rate),
+                  Conv((3, 3), 1 => 32, relu),
+                  BatchNorm(32, relu),
+                  MaxPool((2, 2)),
+                  Dropout(dropout_rate),
+                  Conv((3, 3), 32 => 16, relu),
+                  Dropout(dropout_rate),
+                  MaxPool((2, 2)),
+                  Dropout(dropout_rate),
+                  Conv((3, 3), 16 => 10, relu),
+                  Dropout(dropout_rate),
+                  x -> reshape(x, :, size(x, 4)),
+                  Dropout(dropout_rate),
+                  Dense(90, 10),
+                  D,
+                  D, # same layer twice, to test weight-sharing
+                  softmax)
+    return DigitsModel(chain, config)
+end
+
+# Our model acts on input just by applying the chain.
+(m::DigitsModel)(x) = m.chain(x)
+
+model = DigitsModel()
+
+# Setup some fake data
+
+N_train = 10_000
+data_arr = rand(Float32, 28, 28, N_train)
+
+# Partition into batches of size 32
+batch_size = 32
+data = [reshape(data_arr[:, :, I], 28, 28, 1, :)
+        for I in Iterators.partition(1:N_train, batch_size)]
+
+model(data[1])
+model(AllocArray(data[1]))
+
+
+function infer!(predictions, model, data)
+    with_bumper() do
+        for (idx, x) in enumerate(data)
+            @no_escape begin
+                predictions[idx] .= model(x)
+            end
+        end
+    end
+    return predictions
+end
+
+n_class = 10
+predictions = [Matrix{Float32}(undef, n_class, size(x, 4)) for x in data];
+
+alloc_data = AllocArray.(data)
+# @time infer!(predictions, model, data);
+# @time infer!(predictions, model, data);
+
+# alloc_data = AllocArray.(data);
+# @time infer!(predictions, model, alloc_data);
+# @time infer!(predictions, model, alloc_data);

--- a/test/flux.jl
+++ b/test/flux.jl
@@ -123,6 +123,6 @@ end
 
     predictions = fresh_predictions()
     @showtime infer!(predictions, model, data)
-    @showtime infer!(predictions, model, alloc_data)
     @showtime infer!(predictions, model, stride_data)
+    @showtime infer!(predictions, model, alloc_data)
 end

--- a/test/flux.jl
+++ b/test/flux.jl
@@ -1,4 +1,4 @@
-using Flux
+using Flux, Random
 
 model = Chain(Dense(1 => 23, tanh), Dense(23 => 1; bias=false), only)
 
@@ -90,13 +90,14 @@ model(AllocArray(data[1]))
 
 
 function infer!(predictions, model, data)
-    with_bumper() do
-        for (idx, x) in enumerate(data)
-            @no_escape begin
-                predictions[idx] .= model(x)
-            end
+    buf = Bumper.default_buffer()
+    # with_bumper() do
+    for (idx, x) in enumerate(data)
+        @no_escape buf begin
+            predictions[idx] .= model(x)
         end
     end
+    # end
     return predictions
 end
 
@@ -107,6 +108,5 @@ alloc_data = AllocArray.(data)
 # @time infer!(predictions, model, data);
 # @time infer!(predictions, model, data);
 
-# alloc_data = AllocArray.(data);
 # @time infer!(predictions, model, alloc_data);
 # @time infer!(predictions, model, alloc_data);

--- a/test/flux.jl
+++ b/test/flux.jl
@@ -80,9 +80,10 @@ end
 (m::DigitsModel)(x) = m.chain(x)
 
 function infer!(predictions, model, data)
-    # Is this safe? NNlib multithreads some of the layers, so not sure.
-    buf = Bumper.default_buffer()
-    with_bumper(buf) do
+    buf = default_buffer()
+    # Here we use a locked bumper for thread-safety, since NNlib multithreads
+    # some of it's functions.
+    with_locked_bumper(buf) do
         for (idx, x) in enumerate(data)
             @no_escape buf begin
                 predictions[idx] .= model(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using AllocArrays, Bumper
-using Test
+using Test, Aqua
 
 function some_allocating_function(a)
     b = similar(a)
@@ -23,6 +23,11 @@ function bumper_reduction(a)
 end
 
 @testset "AllocArrays.jl" begin
+    @testset "Aqua" begin
+        # We currently do some piracy...
+        Aqua.test_all(AllocArrays; piracy=false)
+    end
+
     a = AllocArray(ones(Float64, 1000))
 
     (; b, c) = some_allocating_function(a)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,8 +23,7 @@ function bumper_reduction(a)
 end
 
 @testset "AllocArrays.jl" begin
-
-    a = AllocArray(ones(Float64, 1000));
+    a = AllocArray(ones(Float64, 1000))
 
     (; b, c) = some_allocating_function(a)
     @test b isa AllocArray
@@ -32,4 +31,6 @@ end
 
     @test bumper_reduction(a) == 2000.0
     @test basic_reduction(a) == 2000.0
+
+    include("flux.jl")
 end


### PR DESCRIPTION
With the type-unstable `similar`, this was very allocation heavy, and slow. By using a `Ref` to fix the type, I can remove allocations but it is still slow.

In `test/flux.jl` I test `infer!` and get
```julia
  4.170443 seconds (78.37 k allocations: 2.991 GiB, 3.57% gc time) # without AllocArray

 10.400651 seconds (73.55 k allocations: 30.624 MiB) # with AllocArray

```
