### PR TITLE
Fix bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,18 +60,18 @@ For a less-toy example, in `test/flux.jl` we test inference over a Flux model:
 
 ```julia
 # Baseline: Array
-infer!(predictions, model, data): 0.457247 seconds (8.02 k allocations: 370.796 MiB, 6.10% gc time)
+infer!(b, predictions, model, data): 0.499735 seconds (8.05 k allocations: 306.796 MiB, 6.47% gc time)
 # Baseline: StrideArray
 stride_data = StrideArray.(data)
-infer!(predictions, model, stride_data): 0.336535 seconds (8.05 k allocations: 370.796 MiB, 6.20% gc time)
+infer!(b, predictions, model, stride_data): 0.364180 seconds (8.05 k allocations: 306.796 MiB, 8.32% gc time)
 # Using AllocArray:
 alloc_data = AllocArray.(data)
-infer!(predictions, model, alloc_data): 0.318736 seconds (13.35 k allocations: 67.225 MiB)
+infer!(b, predictions, model, alloc_data): 0.351953 seconds (13.60 k allocations: 3.221 MiB)
 checked_alloc_data = CheckedAllocArray.(data)
-infer!(predictions, model, checked_alloc_data): 23.673344 seconds (26.15 k allocations: 67.773 MiB)
+infer!(b, predictions, model, checked_alloc_data): 15.522897 seconds (25.54 k allocations: 3.742 MiB)
 ```
 
-We can see in this example, we got much less allocation (and no GC time), and similar runtime. By running larger examples, the gap in allocations can be much larger; here we use a 64 MiB buffer that we allocate each `infer!` call, which accounts for most of the memory usage.
+We can see in this example, we got 100x less allocation (and no GC time), and similar runtime, for `AllocArray`s. We can see `CheckedAllocArrays` are far slower here.
 
 ## Design notes
 

--- a/src/AllocArray.jl
+++ b/src/AllocArray.jl
@@ -44,8 +44,8 @@ Base.size(a::AllocArray) = size(getfield(a, :arr))
 Base.IndexStyle(::Type{<:AllocArray{T,N,Arr}}) where {T,N,Arr} = Base.IndexStyle(Arr)
 
 # used only by broadcasting?
-function Base.similar(::Type{AllocArray{T,N,Arr}}, dims::Dims) where {T,N,Arr}
-    return alloc_similar(CURRENT_ALLOCATOR[], AllocArray{T,N,Arr}, dims)
+function Base.similar(::Type{<:AllocArray{T}}, dims::Dims) where {T}
+    return alloc_similar(CURRENT_ALLOCATOR[], AllocArray{T}, dims)
 end
 
 function Base.similar(a::AllocArray, ::Type{T}, dims::Dims) where {T}
@@ -56,13 +56,13 @@ end
 ##### Broadcasting
 #####
 
-function Base.BroadcastStyle(::Type{AllocArray{T,N,Arr}}) where {T,N,Arr}
-    return Broadcast.ArrayStyle{AllocArray{T,N,Arr}}()
+function Base.BroadcastStyle(::Type{<:AllocArray})
+    return ArrayStyle{AllocArray}()
 end
 
-function Base.similar(bc::Broadcasted{ArrayStyle{AllocArray{T,N,Arr}}},
-                      ::Type{ElType}) where {T,N,Arr,ElType}
-    return similar(AllocArray{T,N,Arr}, axes(bc))
+function Base.similar(bc::Broadcasted{ArrayStyle{AllocArray}},
+                      ::Type{T}) where {T}
+    return similar(AllocArray{T}, axes(bc))
 end
 
 #####

--- a/src/CheckedAllocArray.jl
+++ b/src/CheckedAllocArray.jl
@@ -121,25 +121,31 @@ end
 Base.IndexStyle(::Type{<:CheckedAllocArray{T,N,Arr}}) where {T,N,Arr} = Base.IndexStyle(Arr)
 
 # used only by broadcasting?
-function Base.similar(::Type{CheckedAllocArray{T,N,Arr}}, dims::Dims) where {T,N,Arr}
-    return alloc_similar(CURRENT_ALLOCATOR[], CheckedAllocArray{T,N,Arr}, dims)
+function Base.similar(::Type{<:CheckedAllocArray{T, N, Arr}}, dims::Dims) where {T, N, Arr}
+    return alloc_similar(CURRENT_ALLOCATOR[], CheckedAllocArray{T, N, Arr}, dims)
 end
 
 function Base.similar(a::CheckedAllocArray, ::Type{T}, dims::Dims) where {T}
     return alloc_similar(CURRENT_ALLOCATOR[], a, T, dims)
 end
 
+
+function alloc_similar(args...)
+    @show map(typeof, args)
+    @show args[2]
+    error("no")
+end
 #####
 ##### Broadcasting
 #####
 
-function Base.BroadcastStyle(::Type{CheckedAllocArray{T,N,Arr}}) where {T,N,Arr}
-    return Broadcast.ArrayStyle{CheckedAllocArray{T,N,Arr}}()
+function Base.BroadcastStyle(::Type{<:CheckedAllocArray})
+    return ArrayStyle{CheckedAllocArray}()
 end
 
-function Base.similar(bc::Broadcasted{ArrayStyle{CheckedAllocArray{T,N,Arr}}},
-                      ::Type{ElType}) where {T,N,Arr,ElType}
-    return similar(CheckedAllocArray{T,N,Arr}, axes(bc))::CheckedAllocArray
+function Base.similar(bc::Broadcasted{ArrayStyle{CheckedAllocArray}},
+                      ::Type{T}) where {T}
+    return alloc_similar(CURRENT_ALLOCATOR[], CheckedAllocArray{T}, Base.to_shape(axes(bc)))::CheckedAllocArray
 end
 
 #####

--- a/src/CheckedAllocArray.jl
+++ b/src/CheckedAllocArray.jl
@@ -121,20 +121,14 @@ end
 Base.IndexStyle(::Type{<:CheckedAllocArray{T,N,Arr}}) where {T,N,Arr} = Base.IndexStyle(Arr)
 
 # used only by broadcasting?
-function Base.similar(::Type{<:CheckedAllocArray{T, N, Arr}}, dims::Dims) where {T, N, Arr}
-    return alloc_similar(CURRENT_ALLOCATOR[], CheckedAllocArray{T, N, Arr}, dims)
+function Base.similar(::Type{<:CheckedAllocArray{T}}, dims::Dims) where {T}
+    return alloc_similar(CURRENT_ALLOCATOR[], CheckedAllocArray{T}, dims)
 end
 
 function Base.similar(a::CheckedAllocArray, ::Type{T}, dims::Dims) where {T}
     return alloc_similar(CURRENT_ALLOCATOR[], a, T, dims)
 end
 
-
-function alloc_similar(args...)
-    @show map(typeof, args)
-    @show args[2]
-    error("no")
-end
 #####
 ##### Broadcasting
 #####
@@ -145,7 +139,7 @@ end
 
 function Base.similar(bc::Broadcasted{ArrayStyle{CheckedAllocArray}},
                       ::Type{T}) where {T}
-    return alloc_similar(CURRENT_ALLOCATOR[], CheckedAllocArray{T}, Base.to_shape(axes(bc)))::CheckedAllocArray
+    return similar(CheckedAllocArray{T}, axes(bc))::CheckedAllocArray
 end
 
 #####

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,4 +39,12 @@ end
 
     include("flux.jl")
     include("checked.jl")
+
+    # Bug reported here:
+    # https://julialang.zulipchat.com/#narrow/stream/137791-general/topic/AllocArrays.2Ejl/near/398698500
+    a = AllocArray(1:4)
+    @test a[1:2] .+ a[3:4]' isa AllocArray
+
+    a = CheckedAllocArray(1:4)
+    @test a[1:2] .+ a[3:4]' isa CheckedAllocArray
 end


### PR DESCRIPTION
I made my `ArrayStyle` too complicated, and then tried to dispatch `similar` to overly-specific types. Here I made the hardcoded dependence on `Array` more obvious (but it was already there) and just dispatch to `Array{T}` when appropriate.

Also took the opportunity to clarify the readme benchmark by hoisting the 64 MiB buffer, so the posted allocations would go down.

Fixes the bug @mcabbott found in https://julialang.zulipchat.com/#narrow/stream/137791-general/topic/AllocArrays.2Ejl/near/398698500