### PR TITLE
Update Bumper compat to v0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AllocArrays"
 uuid = "5c00bae2-1499-4716-9206-27f63fd08a44"
 authors = ["Eric P. Hanson"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
@@ -11,7 +11,7 @@ ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
 
 [compat]
 Aqua = "0.7"
-Bumper = "0.5"
+Bumper = "0.5, 0.6, 0.7"
 ConcurrentUtilities = "2.2.1"
 PrecompileTools = "1.2"
 ScopedValues = "1"


### PR DESCRIPTION
Update Bumper to v0.7 because it drops StrideArraysCore.jl, which overrides the dispatch of basically all array operations.