### PR TITLE
Breaking: always represent inner array as UnsafeArray

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }} - Bumper ${{ matrix.bumper }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,15 +31,15 @@ jobs:
           - x64
           - x86
     steps:
-      - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
         with:
           files: lcov.info

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,50 +1,26 @@
-name: Documentation
+name: Documenter
 on:
   push:
-    branches: [main]
-    tags: '*'
-    paths:
-      - '.github/workflows/docs.yml'
-      - 'src/**'
-      - 'docs/**'
-      - 'Project.toml'
+    branches: [main, master]
+    tags: [v*]
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - '.github/workflows/docs.yml'
-      - 'src/**'
-      - 'docs/**'
-      - 'Project.toml'
 
 jobs:
-  Documentation:
-    # Run on push's or non-draft PRs
-    if: (github.event_name == 'push') || (github.event.pull_request.draft == false) || (github.event_name == 'workflow_dispatch')
+  Documenter:
+    permissions:
+      contents: write
+      statuses: write
+    name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
-          version: "1.8"
-      - name: Cache artifacts
-        uses: actions/cache@v2
+          version: '1'                         # replace this with whatever version you need
+          show-versioninfo: true               # this causes versioninfo to be printed to the action log
+      - uses: julia-actions/cache@v2              # cache using https://github.com/julia-actions/cache
+      - uses: julia-actions/julia-buildpkg@v1  # if package requires Pkg.build()
+      - uses: julia-actions/julia-docdeploy@v1
         env:
-          cache-name: cache-artifacts
-        with:
-          path: |
-            ~/.julia/artifacts
-          key: ${{ runner.os }}-docs-${{ env.cache-name }}-${{ hashFiles('**/docs/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-docs-${{ env.cache-name }}-
-            ${{ runner.os }}-docs-
-            ${{ runner.os }}-
-      - name: Install dependencies
-        shell: julia --color=yes --project=docs/ {0}
-        run: |
-          using Pkg
-          Pkg.develop(PackageSpec(path=pwd()))
-          Pkg.instantiate()
-      - uses: julia-actions/julia-docdeploy@releases/v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,11 +16,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1'                         # replace this with whatever version you need
+          version: '1.10'                         # replace this with whatever version you need
           show-versioninfo: true               # this causes versioninfo to be printed to the action log
       - uses: julia-actions/cache@v2              # cache using https://github.com/julia-actions/cache
       - uses: julia-actions/julia-buildpkg@v1  # if package requires Pkg.build()
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key

--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 Aqua = "0.7"
 Bumper = "0.7"
 ConcurrentUtilities = "2.2.1"
+Functors = "0.5.2"
 PrecompileTools = "1.2"
 ScopedValues = "1"
 UnsafeArrays = "1.0.6"
@@ -22,8 +23,9 @@ julia = "1.10"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Flux", "Random", "Test"]
+test = ["Aqua", "Flux", "Functors", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,6 @@ Bumper = "0.7"
 ConcurrentUtilities = "2.2.1"
 PrecompileTools = "1.2"
 ScopedValues = "1"
-StrideArraysCore = "0.5.1"
 UnsafeArrays = "1.0.6"
 julia = "1.10"
 
@@ -24,8 +23,7 @@ julia = "1.10"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-StrideArraysCore = "7792a7ef-975c-4747-a70f-980b88e8d1da"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Flux", "Random", "StrideArraysCore", "Test"]
+test = ["Aqua", "Flux", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,14 @@
 name = "AllocArrays"
 uuid = "5c00bae2-1499-4716-9206-27f63fd08a44"
 authors = ["Eric P. Hanson"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 ConcurrentUtilities = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
+UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [compat]
 Aqua = "0.7"
@@ -16,6 +17,7 @@ ConcurrentUtilities = "2.2.1"
 PrecompileTools = "1.2"
 ScopedValues = "1"
 StrideArraysCore = "0.5.1"
+UnsafeArrays = "1.0.6"
 julia = "1.10"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -60,12 +60,11 @@ For a less-toy example, in `test/flux.jl` we test inference over a Flux model:
 
 ```julia
 # Baseline: Array
-infer!(b, predictions, model, data): 0.260319 seconds (6.76 k allocations: 221.507 MiB, 50.35% gc time)
-# Using AllocArray:
+infer!(b, predictions, model, data): 0.163573 seconds (6.77 k allocations: 221.508 MiB, 16.42% gc time)# Using AllocArray:
 alloc_data = AllocArray.(data)
-infer!(b, predictions, model, alloc_data): 0.114539 seconds (8.68 k allocations: 847.672 KiB)
+infer!(b, predictions, model, alloc_data): 0.114566 seconds (8.72 k allocations: 777.547 KiB)
 checked_alloc_data = CheckedAllocArray.(data)
-infer!(b, predictions, model, checked_alloc_data): 13.225971 seconds (22.66 k allocations: 1.444 MiB)
+infer!(b, predictions, model, checked_alloc_data): 13.721077 seconds (22.54 k allocations: 1.354 MiB)
 ```
 
 We can see in this example, we got 200x less allocation (and no GC time), and similar runtime, for `AllocArray`s. We can see `CheckedAllocArrays` are far slower here.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ For a less-toy example, in `test/flux.jl` we test inference over a Flux model:
 infer!(b, predictions, model, data): 0.260319 seconds (6.76 k allocations: 221.507 MiB, 50.35% gc time)
 # Using AllocArray:
 alloc_data = AllocArray.(data)
-infer!(b, predictions, model, alloc_data): 0.114539 seconds (8.68 k allocations: 847.672 KiB)checked_alloc_data = CheckedAllocArray.(data)
+infer!(b, predictions, model, alloc_data): 0.114539 seconds (8.68 k allocations: 847.672 KiB)
+checked_alloc_data = CheckedAllocArray.(data)
 infer!(b, predictions, model, checked_alloc_data): 13.225971 seconds (22.66 k allocations: 1.444 MiB)
 ```
 

--- a/julia_57799.jl
+++ b/julia_57799.jl
@@ -1,0 +1,48 @@
+using AllocArrays, BenchmarkTools, UnsafeArrays
+
+function mycopy(dest, src, iter)
+    # precondition: dest and src do not alias
+    # precondition: the iterators of dest and src are equal
+    for i in iter
+        @inbounds dest[i] = src[i]
+    end
+    return dest
+end
+
+b = BumperAllocator(2^30);
+arr = rand(Float32, 50000000);
+arr2 = similar(arr);
+a = AllocArray(arr);
+
+println("With mycopy(arr2, arr, eachindex(arr2)):")
+display(@benchmark mycopy(arr2, arr, eachindex(arr2)))
+
+println("With a = AllocArray(a)")
+display(@benchmark with_allocator(b) do
+    c = similar(a)
+    mycopy(c, a, eachindex(c))
+end setup=(reset!(b)) evals=1)
+
+# julia> include("bench.jl")
+# With mycopy(arr2, arr, eachindex(arr2)):
+# BenchmarkTools.Trial: 627 samples with 1 evaluation per sample.
+#  Range (min … max):  6.662 ms … 38.670 ms  ┊ GC (min … max): 0.00% … 0.00%
+#  Time  (median):     7.151 ms              ┊ GC (median):    0.00%
+#  Time  (mean ± σ):   7.950 ms ±  2.168 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%
+
+#   █▇                                                          
+#   ███▅▄▄▃▄▄▃▃▃▃▃▃▃▃▄▆▄▃▃▃▂▃▃▃▃▃▃▂▂▁▂▁▂▂▁▁▂▁▂▁▁▂▂▁▁▁▁▁▁▂▁▁▁▁▂ ▃
+#   6.66 ms        Histogram: frequency by time          14 ms <
+
+#  Memory estimate: 16 bytes, allocs estimate: 1.
+# With a = AllocArray(a)
+# BenchmarkTools.Trial: 698 samples with 1 evaluation per sample.
+#  Range (min … max):  6.659 ms …  17.031 ms  ┊ GC (min … max): 0.00% … 0.00%
+#  Time  (median):     6.789 ms               ┊ GC (median):    0.00%
+#  Time  (mean ± σ):   7.166 ms ± 941.846 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
+
+#   █▇▄▄▂ ▁   ▁▁    ▁                                            
+#   ██████████████▇▇██▆▇▇▆▇█▅▇▇▇▅▆▆▁▄▁▄▆▁▄▁▆▄▅▅▁▆▅▄▆▅▄▁▆▅▅▁▁▄▅▄ ▇
+#   6.66 ms      Histogram: log(frequency) by time      10.1 ms <
+
+#  Memory estimate: 384 bytes, allocs estimate: 13.

--- a/src/AllocArray.jl
+++ b/src/AllocArray.jl
@@ -42,6 +42,8 @@ struct AllocArray{T,N} <: DenseArray{T,N}
     function AllocArray(arr::UnsafeArray)
         return new{eltype(arr),ndims(arr)}(arr, nothing)
     end
+
+    AllocArray(a::AllocArray) = a
 end
 
 AllocMatrix{T} = AllocArray{T,2}

--- a/src/AllocArray.jl
+++ b/src/AllocArray.jl
@@ -33,17 +33,19 @@ struct AllocArray{T,N} <: DenseArray{T,N}
     arr::UnsafeArray{T,N}
     gcref::Any
 
-    function AllocArray(gcref::AbstractArray)
+    AllocArray(gcref::AbstractArray{T,N}) where {T,N} = AllocArray{T,N}(gcref)
+    function AllocArray{T,N}(gcref::AbstractArray{T,N}) where {T,N}
         arr = UnsafeArray(pointer(gcref), size(gcref))
         return new{eltype(arr),ndims(arr)}(arr, gcref)
     end
 
     # already allocated with Bumper, no gcref needed
-    function AllocArray(arr::UnsafeArray)
-        return new{eltype(arr),ndims(arr)}(arr, nothing)
-    end
+    AllocArray(arr::UnsafeArray{T,N}) where {T,N} = AllocArray{T,N}(arr)
+    AllocArray{T,N}(arr::UnsafeArray{T,N}) where {T,N} = new{T,N}(arr, nothing)
+
 
     AllocArray(a::AllocArray) = a
+    AllocArray{T,N}(a::AllocArray{T,N}) where {T,N} = a
 end
 
 AllocMatrix{T} = AllocArray{T,2}

--- a/test/checked.jl
+++ b/test/checked.jl
@@ -77,5 +77,5 @@ end
 
     @test sprint(showerror, InvalidMemoryException()) == "InvalidMemoryException: Array accessed after its memory has been deallocated."
 
-    @test Base.parent(c) === inner
+    @test c.alloc_array.gcref === inner
 end

--- a/test/flux.jl
+++ b/test/flux.jl
@@ -1,4 +1,4 @@
-using Flux, Random, StrideArraysCore
+using Flux, Random
 
 function bumper_run(model, data)
     b = UncheckedBumperAllocator(2^25) # 32 MiB
@@ -122,26 +122,13 @@ end
     infer!(b, preds_checked_alloc, model, checked_alloc_data)
 
     preds_stride = fresh_predictions()
-    stride_data = StrideArray.(data)
     infer!(b, preds_stride, model, stride_data)
 
     @test preds_data ≈ preds_alloc
-    @test preds_data ≈ preds_stride
     @test preds_data ≈ preds_checked_alloc
 
     predictions = fresh_predictions()
-    @showtime infer!(b, predictions, model, data)
-    @showtime infer!(b, predictions, model, stride_data)
-    @showtime infer!(b, predictions, model, alloc_data)
-    @showtime infer!(b, predictions, model, checked_alloc_data)
-
-    # Note: for max perf, consider
-    # using Functors
-    # model = fmap(AllocArray ∘ PtrArray, model; exclude = x -> x isa AbstractArray)
-    # alloc_data = AllocArray.(PtrArray.(data))
-    # @showtime infer!(b, predictions, model, alloc_data)
-    # @showtime infer!(b, predictions, model, alloc_data)
-    # Together, that ensure everything is an `AllocArray(PtrArray(...))`
-    # This seems to help with runtime although not a huge amount,
-    # and doesn't really help with allocations.
+    @showtime infer!(b, predictions, model, data);
+    @showtime infer!(b, predictions, model, alloc_data);
+    @showtime infer!(b, predictions, model, checked_alloc_data);
 end

--- a/test/flux.jl
+++ b/test/flux.jl
@@ -121,9 +121,6 @@ end
     preds_checked_alloc = fresh_predictions()
     infer!(b, preds_checked_alloc, model, checked_alloc_data)
 
-    preds_stride = fresh_predictions()
-    infer!(b, preds_stride, model, stride_data)
-
     @test preds_data ≈ preds_alloc
     @test preds_data ≈ preds_checked_alloc
 

--- a/test/flux.jl
+++ b/test/flux.jl
@@ -1,4 +1,12 @@
-using Flux, Random
+using Flux, Random, Functors
+
+function recursive_alloc_arrays(obj)
+    return fmap(x -> begin
+        x isa AbstractArray || return x
+        isbitstype(eltype(x)) || return x
+        return AllocArray(x)
+    end, obj; exclude=x -> x isa AbstractArray{<:Number} || x isa Function)
+end
 
 function bumper_run(model, data)
     b = UncheckedBumperAllocator(2^25) # 32 MiB
@@ -118,14 +126,20 @@ end
     preds_alloc = fresh_predictions()
     infer!(b, preds_alloc, model, alloc_data)
 
+    preds_alloc_aa = fresh_predictions()
+    aa_model = recursive_alloc_arrays(model)
+    infer!(b, preds_alloc_aa, aa_model, alloc_data)
+
     preds_checked_alloc = fresh_predictions()
     infer!(b, preds_checked_alloc, model, checked_alloc_data)
 
     @test preds_data ≈ preds_alloc
+    @test preds_data ≈ preds_alloc_aa
     @test preds_data ≈ preds_checked_alloc
 
     predictions = fresh_predictions()
     @showtime infer!(b, predictions, model, data);
     @showtime infer!(b, predictions, model, alloc_data);
+    @showtime infer!(b, predictions, aa_model, alloc_data);
     @showtime infer!(b, predictions, model, checked_alloc_data);
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,4 +47,7 @@ end
 
     a = CheckedAllocArray(collect(1:4))
     @test a[1:2] .+ a[3:4]' isa CheckedAllocArray
+
+    # Constructor does not recurse
+    @test AllocArray(a) === a
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,5 +49,6 @@ end
     @test a[1:2] .+ a[3:4]' isa CheckedAllocArray
 
     # Constructor does not recurse
-    @test AllocArray(a) === a
+    @test AllocArray(a).gcref === a.gcref
+    @test AllocArray(a).arr === a.arr
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,10 +45,11 @@ end
     a = AllocArray(collect(1:4))
     @test a[1:2] .+ a[3:4]' isa AllocArray
 
-    a = CheckedAllocArray(collect(1:4))
-    @test a[1:2] .+ a[3:4]' isa CheckedAllocArray
+    c = CheckedAllocArray(collect(1:4))
+    @test c[1:2] .+ c[3:4]' isa CheckedAllocArray
 
     # Constructor does not recurse
+    a = AllocArray(collect(1:4))
     @test AllocArray(a).gcref === a.gcref
     @test AllocArray(a).arr === a.arr
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,9 +42,9 @@ end
 
     # Bug reported here:
     # https://julialang.zulipchat.com/#narrow/stream/137791-general/topic/AllocArrays.2Ejl/near/398698500
-    a = AllocArray(1:4)
+    a = AllocArray(collect(1:4))
     @test a[1:2] .+ a[3:4]' isa AllocArray
 
-    a = CheckedAllocArray(1:4)
+    a = CheckedAllocArray(collect(1:4))
     @test a[1:2] .+ a[3:4]' isa CheckedAllocArray
 end


### PR DESCRIPTION
This avoids the issue in https://github.com/JuliaLang/julia/issues/57799 and seems to reduce allocations using the workaround from https://github.com/JuliaLang/julia/issues/57799#issuecomment-2734347938

