### PR TITLE
fix GC issue by globally rooting values

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AllocArrays"
 uuid = "5c00bae2-1499-4716-9206-27f63fd08a44"
 authors = ["Eric P. Hanson"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,4 +52,6 @@ end
     a = AllocArray(collect(1:4))
     @test AllocArray(a).gcref === a.gcref
     @test AllocArray(a).arr === a.arr
+
+    @testset "test gc" include("test_gc.jl")
 end

--- a/test/test_gc.jl
+++ b/test/test_gc.jl
@@ -1,0 +1,36 @@
+using AllocArrays, Test
+
+function foo()
+    arr = zeros(1000, 1000)
+    a = AllocArray(arr)
+    GC.gc()
+    rand(1000, 1000)
+    rand(1000, 1000)
+    return a[1, 1]
+end
+
+function loop(verbose=false)
+    for i in 1:20
+        verbose && println(i)
+        f = foo()
+        if !iszero(f)
+            @show f
+        end
+        @test f == 0.0
+    end
+end
+
+loop()
+
+GC.gc()
+GC.gc()
+
+@test isempty(AllocArrays.GC_ROOTS)
+
+if Threads.nthreads() > 1
+    println("Running multithreaded gc test")
+    Threads.@threads for i=1:2
+        @info "Running on $(Threads.threadid()) for iteration $i"
+        loop()
+    end
+end


### PR DESCRIPTION
in https://github.com/ericphanson/AllocArrays.jl/pull/18 I did not use UnsafeArrays correctly: I assumed the `gcref` field would be enough to root the arrays to Julia's GC would not free the memory, making the pointer inside the UnsafeArray invalid. However it is not; Julia can figure out we never use `gcref` and free the memory, as the `test/test_gc.jl` file shows; it fails on main.

This fixes it, but at a big performance cost with
```julia
forward pass: 1.457254 seconds (5.59 k allocations: 11.969 MiB)
bumper_yolomod(b, batch_aa; detectThresh = 0.5, overlapThresh = 0.8): 1.500037 seconds (19.29 k allocations: 12.636 MiB)
```
compared to ~1s without allocarrays on https://github.com/r3tex/ObjectDetector.jl/pull/101