### PR TITLE
rm UnsafeArrays, use previous way

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,13 @@
 name = "AllocArrays"
 uuid = "5c00bae2-1499-4716-9206-27f63fd08a44"
 authors = ["Eric P. Hanson"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 ConcurrentUtilities = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
-UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [compat]
 Aqua = "0.7"
@@ -17,7 +16,6 @@ ConcurrentUtilities = "2.2.1"
 Functors = "0.5.2"
 PrecompileTools = "1.2"
 ScopedValues = "1"
-UnsafeArrays = "1.0.6"
 julia = "1.10"
 
 [extras]

--- a/test/checked.jl
+++ b/test/checked.jl
@@ -77,5 +77,5 @@ end
 
     @test sprint(showerror, InvalidMemoryException()) == "InvalidMemoryException: Array accessed after its memory has been deallocated."
 
-    @test c.alloc_array.gcref === inner
+    @test Base.parent(c) === inner
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,14 +42,13 @@ end
 
     # Bug reported here:
     # https://julialang.zulipchat.com/#narrow/stream/137791-general/topic/AllocArrays.2Ejl/near/398698500
-    a = AllocArray(collect(1:4))
+    a = AllocArray(1:4)
     @test a[1:2] .+ a[3:4]' isa AllocArray
 
-    c = CheckedAllocArray(collect(1:4))
+    c = CheckedAllocArray(1:4)
     @test c[1:2] .+ c[3:4]' isa CheckedAllocArray
 
     # Constructor does not recurse
-    a = AllocArray(collect(1:4))
-    @test AllocArray(a).gcref === a.gcref
+    a = AllocArray(1:4)
     @test AllocArray(a).arr === a.arr
 end


### PR DESCRIPTION
this reverts the UnsafeArray related changes in #18 since they introduce memory safety issues. They are also not needed! I get equally good results with this PR for https://github.com/r3tex/ObjectDetector.jl/pull/101:

```julia
forward pass: 0.907787 seconds (4.30 k allocations: 6.263 GiB, 5.95% gc time)
yolomod(batch, detectThresh = 0.5, overlapThresh = 0.8): 0.961214 seconds (47.01 k allocations: 6.298 GiB, 5.62% gc time, 2.79% compilation time)
forward pass: 1.293893 seconds (4.30 k allocations: 6.263 GiB, 21.28% gc time)
yolomod(batch, detectThresh = 0.5, overlapThresh = 0.8): 1.320383 seconds (6.89 k allocations: 6.295 GiB, 20.86% gc time)
forward pass: 0.924500 seconds (4.30 k allocations: 6.263 GiB, 4.77% gc time)
yolomod(batch, detectThresh = 0.5, overlapThresh = 0.8): 0.949379 seconds (6.89 k allocations: 6.295 GiB, 4.64% gc time)

forward pass: 1.132717 seconds (6.62 k allocations: 12.082 MiB)
bumper_yolomod(b, batch_aa; detectThresh = 0.5, overlapThresh = 0.8): 1.181193 seconds (26.75 k allocations: 13.084 MiB, 1.14% compilation time)
forward pass: 1.130855 seconds (6.62 k allocations: 12.082 MiB)
bumper_yolomod(b, batch_aa; detectThresh = 0.5, overlapThresh = 0.8): 1.167223 seconds (9.09 k allocations: 12.159 MiB)
forward pass: 0.787238 seconds (6.62 k allocations: 12.082 MiB)
bumper_yolomod(b, batch_aa; detectThresh = 0.5, overlapThresh = 0.8): 0.822033 seconds (9.09 k allocations: 12.159 MiB)
```

I think the vectorization thing was a red herring. Maybe the important bit is the no-op constructors to prevent nesting, which are retained here.