### PR TITLE
support Adapt

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,29 +1,30 @@
 name = "AllocArrays"
 uuid = "5c00bae2-1499-4716-9206-27f63fd08a44"
 authors = ["Eric P. Hanson"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 ConcurrentUtilities = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
 
 [compat]
+Adapt = "4.3.0"
 Aqua = "0.7"
 Bumper = "0.7"
 ConcurrentUtilities = "2.2.1"
-Functors = "0.5.2"
 PrecompileTools = "1.2"
 ScopedValues = "1"
 julia = "1.10"
 
 [extras]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Flux", "Functors", "Random", "Test"]
+test = ["Adapt", "Aqua", "Flux", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Eric P. Hanson"]
 version = "0.4.1"
 
 [deps]
-Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 ConcurrentUtilities = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
@@ -12,15 +11,23 @@ ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
 
 [compat]
 Adapt = "4.3.0"
-Aqua = "0.7"
+Aqua = "0.8"
 Bumper = "0.7"
 ConcurrentUtilities = "2.2.1"
 PrecompileTools = "1.2"
 ScopedValues = "1"
+Random = "1"
+Test = "1"
+Flux = "0.16"
 julia = "1.10"
 
-[extras]
+[weakdeps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+
+[extensions]
+AdaptExt = "Adapt"
+
+[extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ We can see in this example, we got 200x less allocation (and no GC time), and si
 
 ## Usage with Flux
 
-For reducing allocations as much as possible with Flux models, we can use `Adapt.adapt(AllocArray, model)` to convert a model to use `AllocArray`s. This will convert all arrays in the model to `AllocArray`s, and will also convert any arrays in the model's parameters to `AllocArray`s. This way, any layers during the forward pass of the model which use `similar` calls based on the layer's parameters will use the bump allocator, when the forward pass is invoked within `with_allocator`.
+For reducing allocations as much as possible with Flux models, we can use `Adapt.adapt(AllocArray, model)` to convert a model to use `AllocArray`s (after calling `using Adapt`). This will convert all arrays in the model to `AllocArray`s, and will also convert any arrays in the model's parameters to `AllocArray`s. This way, any layers during the forward pass of the model which use `similar` calls based on the layer's parameters will use the bump allocator, when the forward pass is invoked within `with_allocator`.
 
 Additionally, we suggest using an `infer_batches!` function similar to the following:
 

--- a/ext/AdaptExt.jl
+++ b/ext/AdaptExt.jl
@@ -1,0 +1,9 @@
+module AdaptExt
+using Adapt, AllocArrays
+
+# AllocArrays should be seen as "storage" like CuArray, not a wrapper like Transpose,
+# since we want to recurse through models and convert arrays to AllocArrays, so that
+# in the forward pass we can use our bump allocator
+Adapt.adapt_storage(::Type{<:AllocArray}, xs::AbstractArray) = AllocArray(xs)
+
+end # AdaptExt

--- a/src/AllocArray.jl
+++ b/src/AllocArray.jl
@@ -79,15 +79,6 @@ function Base.similar(bc::Broadcasted{ArrayStyle{AllocArray}},
 end
 
 #####
-##### Adapt.jl
-#####
-
-# AllocArrays should be seen as "storage" like CuArray, not a wrapper like Transpose,
-# since we want to recurse through models and convert arrays to AllocArrays, so that
-# in the forward pass we can use our bump allocator
-Adapt.adapt_storage(::Type{<:AllocArray}, xs::AbstractArray) = AllocArray(xs)
-
-#####
 ##### StridedArray interface
 #####
 

--- a/src/AllocArray.jl
+++ b/src/AllocArray.jl
@@ -82,7 +82,10 @@ end
 ##### Adapt.jl
 #####
 
-# Adapt.adapt_structure(to, x::AllocArray) = AllocArray(adapt(to, parent(x)))
+# AllocArrays should be seen as "storage" like CuArray, not a wrapper like Transpose,
+# since we want to recurse through models and convert arrays to AllocArrays, so that
+# in the forward pass we can use our bump allocator
+Adapt.adapt_storage(::Type{<:AllocArray}, xs::AbstractArray) = AllocArray(xs)
 
 #####
 ##### StridedArray interface

--- a/src/AllocArrays.jl
+++ b/src/AllocArrays.jl
@@ -4,7 +4,6 @@ using ScopedValues: ScopedValue, with
 using Bumper
 using ConcurrentUtilities
 using PrecompileTools
-using Adapt: Adapt
 
 # Two array types
 export AllocArray

--- a/src/AllocArrays.jl
+++ b/src/AllocArrays.jl
@@ -4,6 +4,7 @@ using ScopedValues: ScopedValue, with
 using Bumper
 using ConcurrentUtilities
 using PrecompileTools
+using Adapt: Adapt
 
 # Two array types
 export AllocArray

--- a/test/flux.jl
+++ b/test/flux.jl
@@ -122,6 +122,10 @@ end
 
     preds_alloc_aa = fresh_predictions()
     aa_model = Adapt.adapt(AllocArray, model)
+
+    # check we've truly `adapt`'d the model to AllocArrays
+    @test aa_model.chain.layers[2].weight isa AllocArray
+    
     infer_batches!(b, preds_alloc_aa, aa_model, alloc_data)
 
     preds_checked_alloc = fresh_predictions()


### PR DESCRIPTION
this makes it easy to recursively convert a model to use AllocArrays: just `Adapt.adapt(AllocArray, model)`