### PR TITLE
Add support for growable SlabBuffer, and use by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AllocArrays"
 uuid = "5c00bae2-1499-4716-9206-27f63fd08a44"
 authors = ["Eric P. Hanson"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ function bumper_reduction!(b, a)
     end
 end
 
-b = BumperAllocator(2^24) # 16 MiB
+b = BumperAllocator() # Uses a SlabBuffer which grows as needed
 a = AllocArray(arr);
 
 @time bumper_reduction!(b, a) #  0.205106 seconds (893.40 k allocations: 44.941 MiB, 2.62% gc time, 99.67% compilation time)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ function bumper_reduction!(b, a)
 end
 
 b = BumperAllocator() # Uses a SlabBuffer which grows as needed
+# b = BumperAllocator(2^24) # alternatively specify fixed bytes size of an AllocBuffer (16 MiB), which may be more performant
 a = AllocArray(arr);
 
 @time bumper_reduction!(b, a) #  0.205106 seconds (893.40 k allocations: 44.941 MiB, 2.62% gc time, 99.67% compilation time)
@@ -116,6 +117,9 @@ The key points here are:
 ## Design notes
 
 The user is responsible for constructing buffers (via `AllocBuffer` or the constructors `BumperAllocator` and `UncheckedBumperAllocator`) and for resetting them (`reset!`).
+`BumperAllocator()` is backed by a growable `SlabBuffer`. To set a fixed buffer, which may be more performant,
+use `BumperAllocator(bytes)`.
+
 No implicit buffers are used, and `reset!` is never called in the package. These choices are deliberate: the caller must construct the buffer, pass it to AllocArrays.jl to be used when appropriate, and reset it when they are done.
 
 In particular, the caller must:

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -25,7 +25,7 @@ Allocations inside `@no_escape` must not escape!
 
 ```@repl ex
 function bad_function_1(a)
-    b = BumperAllocator(2^25) # 32 MiB
+    b = BumperAllocator()
     output = []
     with_allocator(b) do
         result = some_allocating_function(a)
@@ -42,7 +42,7 @@ Here is a corrected version:
 
 ```@repl ex
 function good_function_1(a)
-    b = BumperAllocator(2^25) # 32 MiB
+    b = BumperAllocator()
 
     # note, we are not inside `with_allocator`, so we are not making buffer-backed memory
     output = similar(a)
@@ -63,7 +63,7 @@ good_function_1(AllocArray([1]))
 
 ```@repl ex
 function bad_function_2(a)
-    b = BumperAllocator(2^25) # 32 MiB
+    b = BumperAllocator()
     output = Channel(Inf)
     with_allocator(b) do
         @sync for _ = 1:10
@@ -85,7 +85,7 @@ Here is a corrected version:
 
 ```@repl ex
 function good_function_2(a)
-    b = BumperAllocator(2^25) # 32 MiB
+    b = BumperAllocator()
     output = Channel(Inf)
     with_allocator(b) do
         @sync for _ = 1:10
@@ -107,7 +107,7 @@ Or, if we need to reset multiple times as we process the data, we could do a ser
 
 ```@repl ex
 function good_function_2b(a)
-    b = BumperAllocator(2^25) # 32 MiB
+    b = BumperAllocator()
     output = Channel(Inf)
     with_allocator(b) do
         for _ = 1:10
@@ -131,7 +131,7 @@ As shown above, we must be careful about when we reset the buffer. However, if w
 
 ```julia
 function bad_function_3(a, N)
-    b = BumperAllocator(2^25) # 32 MiB
+    b = BumperAllocator()
     output = Channel(Inf)
     with_allocator(b) do
         for _ = 1:N # bad! we are going to allocate `N` times without resetting!

--- a/julia_57799.jl
+++ b/julia_57799.jl
@@ -9,7 +9,7 @@ function mycopy(dest, src, iter)
     return dest
 end
 
-b = BumperAllocator(2^30);
+b = BumperAllocator();
 arr = rand(Float32, 50000000);
 arr2 = similar(arr);
 a = AllocArray(arr);

--- a/src/AllocArrays.jl
+++ b/src/AllocArrays.jl
@@ -27,13 +27,15 @@ const CURRENT_ALLOCATOR = ScopedValue{Allocator}(DEFAULT_ALLOCATOR)
 # PrecompileTools workload
 @setup_workload begin
     @compile_workload begin
-        b = BumperAllocator()
-        a = AllocArray([1])
-        c = CheckedAllocArray(a, MemValid(true))
-        with_allocator(b) do
-            similar(a) .= 1
-            similar(c) .= 1
-            reset!(b)
+        for alloc in (Returns(BumperAllocator()), Returns(BumperAllocator(2^10))) # (SlabBuffer, 1 KiB)
+            b = alloc()
+            a = AllocArray([1])
+            c = CheckedAllocArray(a, MemValid(true))
+            with_allocator(b) do
+                similar(a) .= 1
+                similar(c) .= 1
+                reset!(b)
+            end
         end
     end
 end

--- a/src/AllocArrays.jl
+++ b/src/AllocArrays.jl
@@ -27,7 +27,7 @@ const CURRENT_ALLOCATOR = ScopedValue{Allocator}(DEFAULT_ALLOCATOR)
 # PrecompileTools workload
 @setup_workload begin
     @compile_workload begin
-        b = BumperAllocator(2^10) # 1 KiB
+        b = BumperAllocator()
         a = AllocArray([1])
         c = CheckedAllocArray(a, MemValid(true))
         with_allocator(b) do

--- a/src/AllocArrays.jl
+++ b/src/AllocArrays.jl
@@ -29,7 +29,7 @@ const CURRENT_ALLOCATOR = ScopedValue{Allocator}(DEFAULT_ALLOCATOR)
     @compile_workload begin
         for alloc in (() -> BumperAllocator(), () -> BumperAllocator(2^10)) # (SlabBuffer, 1 KiB)
             b = alloc()
-            a = AllocArray([1])
+            a = AllocArray([1.0f0])
             c = CheckedAllocArray(a, MemValid(true))
             with_allocator(b) do
                 similar(a) .= 1

--- a/src/AllocArrays.jl
+++ b/src/AllocArrays.jl
@@ -27,7 +27,7 @@ const CURRENT_ALLOCATOR = ScopedValue{Allocator}(DEFAULT_ALLOCATOR)
 # PrecompileTools workload
 @setup_workload begin
     @compile_workload begin
-        for alloc in (Returns(BumperAllocator()), Returns(BumperAllocator(2^10))) # (SlabBuffer, 1 KiB)
+        for alloc in (() -> BumperAllocator(), () -> BumperAllocator(2^10)) # (SlabBuffer, 1 KiB)
             b = alloc()
             a = AllocArray([1])
             c = CheckedAllocArray(a, MemValid(true))

--- a/src/alloc_interface.jl
+++ b/src/alloc_interface.jl
@@ -109,12 +109,13 @@ struct UncheckedBumperAllocator{B<:Union{AllocBuffer,SlabBuffer}} <: Allocator
 end
 
 """
-    UncheckedBumperAllocator(n_bytes::Int = 0)
+    UncheckedBumperAllocator() -> UncheckedBumperAllocator(SlabBuffer())
+    UncheckedBumperAllocator(n_bytes::Int) -> UncheckedBumperAllocator(AllocBuffer(n_bytes))
 
-If `0` (default) equivalent to `UncheckedBumperAllocator(SlabBuffer(n_bytes))`,
-otherwise `UncheckedBumperAllocator(AllocBuffer(n_bytes))`.
+By default uses a growable `SlabBuffer`, or a `AllocBuffer` of `n_bytes` if provided.
 """
-UncheckedBumperAllocator(n_bytes::Int = 0) = UncheckedBumperAllocator(n_bytes == 0 ? SlabBuffer() : AllocBuffer(n_bytes))
+UncheckedBumperAllocator() = UncheckedBumperAllocator(SlabBuffer())
+UncheckedBumperAllocator(n_bytes::Int) = UncheckedBumperAllocator(AllocBuffer(n_bytes))
 
 """
     reset!(B::UncheckedBumperAllocator)
@@ -210,12 +211,13 @@ function BumperAllocator(B::T) where T <: Union{AllocBuffer, SlabBuffer}
 end
 
 """
-    BumperAllocator(n_bytes::Int = 0)
+    BumperAllocator() -> BumperAllocator(SlabBuffer())
+    BumperAllocator(n_bytes::Int) -> BumperAllocator(AllocBuffer(n_bytes))
 
-If `0` (default) equivalent to `BumperAllocator(SlabBuffer(n_bytes))`,
-otherwise `BumperAllocator(AllocBuffer(n_bytes))`.
+By default uses a growable `SlabBuffer`, or a `AllocBuffer` of `n_bytes` if provided.
 """
-BumperAllocator(n_bytes::Int = 0) = BumperAllocator(n_bytes == 0 ? SlabBuffer() : AllocBuffer(n_bytes))
+BumperAllocator() = BumperAllocator(SlabBuffer())
+BumperAllocator(n_bytes::Int) = BumperAllocator(AllocBuffer(n_bytes))
 
 Base.lock(B::BumperAllocator) = lock(B.lock)
 Base.unlock(B::BumperAllocator) = unlock(B.lock)

--- a/test/checked.jl
+++ b/test/checked.jl
@@ -24,7 +24,7 @@ end
 
 @testset "basic escape" begin
     input = CheckedAllocArray([1.0])
-    for alloc in (Returns(BumperAllocator(2^23)), Returns(BumperAllocator())) # (8 MiB, SlabBuffer)
+    for alloc in (() -> BumperAllocator(2^23), () -> BumperAllocator()) # (8 MiB, SlabBuffer)
         b = alloc()
         y = with_allocator(b) do
             y = similar(input)

--- a/test/checked.jl
+++ b/test/checked.jl
@@ -24,8 +24,8 @@ end
 
 @testset "basic escape" begin
     input = CheckedAllocArray([1.0])
-    @testset "bytes: $bytes" for bytes in (2^23, 0) # (8 MiB, SlabBuffer)
-        b = BumperAllocator(bytes)
+    for alloc in (Returns(BumperAllocator(2^23)), Returns(BumperAllocator())) # (8 MiB, SlabBuffer)
+        b = alloc()
         y = with_allocator(b) do
             y = similar(input)
             y .= 2

--- a/test/flux.jl
+++ b/test/flux.jl
@@ -97,7 +97,7 @@ end
 @testset "More complicated model" begin
     model = DigitsModel()
 
-    for alloc in (Returns(BumperAllocator(2^26)), Returns(BumperAllocator())) # (64 MiB, SlabBuffer)
+    for alloc in (() -> BumperAllocator(2^26), () -> BumperAllocator()) # (64 MiB, SlabBuffer)
         b = alloc()
 
         # Setup some fake data

--- a/test/flux.jl
+++ b/test/flux.jl
@@ -97,8 +97,8 @@ end
 @testset "More complicated model" begin
     model = DigitsModel()
 
-    @testset "bytes: $bytes" for bytes in (2^26, 0) # (64 MiB, SlabBuffer)
-        b = BumperAllocator(bytes)
+    for alloc in (Returns(BumperAllocator(2^26)), Returns(BumperAllocator())) # (64 MiB, SlabBuffer)
+        b = alloc()
 
         # Setup some fake data
         N = 1_000

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ function basic_reduction(a)
 end
 
 function bumper_reduction(a)
-    b = BumperAllocator(2^24) # 16 MiB
+    b = BumperAllocator()
     with_allocator(b) do
         ret = basic_reduction(a)
         reset!(b)


### PR DESCRIPTION
Adds support for the growable SlabBuffer (and uses its default init size).

Also makes it the default if you just call `BumperAllocator()`.

This passes tests locally. 

I haven't looked at performance. There are some performance cons over an AllocBuffer mentioned here https://github.com/MasonProtter/Bumper.jl/blob/main/README.md#slabbuffer