### PR TITLE
add `show` methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AllocArrays"
 uuid = "5c00bae2-1499-4716-9206-27f63fd08a44"
 authors = ["Eric P. Hanson"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"

--- a/src/alloc_interface.jl
+++ b/src/alloc_interface.jl
@@ -123,6 +123,10 @@ By default uses a growable [`AutoscalingAllocBuffer`](@ref) (currently), or a `A
 UncheckedBumperAllocator() = UncheckedBumperAllocator(AutoscalingAllocBuffer())
 UncheckedBumperAllocator(n_bytes::Int) = UncheckedBumperAllocator(AllocBuffer(n_bytes))
 
+function Base.show(io::IO, b::UncheckedBumperAllocator)
+    return print(io, UncheckedBumperAllocator, "(", b.buf, ")")
+end
+
 """
     reset!(B::UncheckedBumperAllocator)
 
@@ -230,6 +234,22 @@ By default uses a growable [`AutoscalingAllocBuffer`](@ref) (currently), or a `A
 """
 BumperAllocator() = BumperAllocator(AutoscalingAllocBuffer())
 BumperAllocator(n_bytes::Int) = BumperAllocator(AllocBuffer(n_bytes))
+
+function Base.show(io::IO, b::BumperAllocator)
+    # pass through the buf, since we auto-wrap with `UncheckedBumperAllocator` in the constructor,
+    # and that's an implementation detail
+    return print(io, BumperAllocator, "(", b.bumper.buf, ")")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", b::BumperAllocator)
+    print(io, b)
+    # for 3-arg show, we'll add a detail about the memory locations if we are tracking any
+    if length(b.mems) > 0
+        plural = length(b.mems) == 1 ? "" : "s"
+        print(io, " (tracking ", length(b.mems), " CheckedAllocArray memory location$plural)")
+    end
+    return nothing
+end
 
 Base.lock(B::BumperAllocator) = lock(B.lock)
 Base.unlock(B::BumperAllocator) = unlock(B.lock)

--- a/test/autoscaling_alloc_buffer.jl
+++ b/test/autoscaling_alloc_buffer.jl
@@ -30,6 +30,10 @@ using Bumper: alloc!, reset_buffer!
     # still not too many additional buffers
     @test length(b.additional_buffers) < 10
 
+    @testset "show" begin
+        @test sprint(show, b) == "AutoscalingAllocBuffer()"
+        @test sprint(show, MIME"text/plain"(), b) == "AutoscalingAllocBuffer() (7.668 MiB used [0.0% in main buffer], capacity 9.690 MiB [0.0% in main buffer] with 7 additional buffers)"
+    end
     # now check reset: we should have more capacity than used last time,
     # while having no additional buffers
     used = amount_used(b)
@@ -46,4 +50,10 @@ using Bumper: alloc!, reset_buffer!
         reset_buffer!(b)
     end
     @test total_capacity(b) < 2n
+
+    @testset "show" begin
+        cap = Base.format_bytes(total_capacity(b))
+        @test sprint(show, b) == "AutoscalingAllocBuffer()"
+        @test sprint(show, MIME"text/plain"(), b) == "AutoscalingAllocBuffer() (0 bytes used, capacity $cap, all in main buffer)"
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,4 +52,18 @@ end
     # Constructor does not recurse
     a = AllocArray(1:4)
     @test AllocArray(a).arr === a.arr
+
+    b = BumperAllocator()
+    @test sprint(show, b) == "BumperAllocator(AutoscalingAllocBuffer())"
+    @test sprint(show, MIME"text/plain"(), b) == "BumperAllocator(AutoscalingAllocBuffer())"
+    x = with_allocator(b) do
+        similar(c, 100, 100)
+    end
+    @test sprint(show, b) == "BumperAllocator(AutoscalingAllocBuffer())"
+    @test sprint(show, MIME"text/plain"(), b) == "BumperAllocator(AutoscalingAllocBuffer()) (tracking 1 CheckedAllocArray memory location)"
+
+    b = UncheckedBumperAllocator()
+    @test sprint(show, b) == "UncheckedBumperAllocator(AutoscalingAllocBuffer())"
+    @test sprint(show, MIME"text/plain"(), b) == "UncheckedBumperAllocator(AutoscalingAllocBuffer())"
+
 end


### PR DESCRIPTION
demo:
```julia
julia> using AllocArrays

julia> b = UncheckedBumperAllocator()
UncheckedBumperAllocator(AutoscalingAllocBuffer())

julia> b = BumperAllocator()
BumperAllocator(AutoscalingAllocBuffer())

julia> AutoscalingAllocBuffer()
AutoscalingAllocBuffer() (0 bytes used, capacity 128.000 MiB, all in main buffer)

julia> println(AutoscalingAllocBuffer())
AutoscalingAllocBuffer()

julia> using Bumper

julia> Bumper.alloc!(b.bumper.buf, UInt8, 10^9)
1000000000-element UnsafeArrays.UnsafeArray{UInt8, 1}:
 0x00
 0x00
 0x00
 0x00
 0x00
    ⋮
 0x00
 0x00
 0x00
 0x00

julia> b
BumperAllocator(AutoscalingAllocBuffer())

julia> b.bumper.buf
AutoscalingAllocBuffer() (953.674 MiB used [0.0% in main buffer], capacity 1.988 GiB [6.3% in main buffer] with 1 additional buffer)

julia> println(b.bumper.buf)
AutoscalingAllocBuffer()
```