### PR TITLE
wip: CachedUpdatelessFunction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Eric P. Hanson"]
 version = "1.1.0"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 ConcurrentUtilities = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
@@ -21,12 +22,6 @@ Test = "1"
 Flux = "0.16"
 julia = "1.10"
 
-[weakdeps]
-Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-
-[extensions]
-AdaptExt = "Adapt"
-
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
@@ -34,4 +29,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Adapt", "Aqua", "Flux", "Random", "Test"]
+test = ["Aqua", "Flux", "Random", "Test"]

--- a/ext/AdaptExt.jl
+++ b/ext/AdaptExt.jl
@@ -1,9 +1,0 @@
-module AdaptExt
-using Adapt, AllocArrays
-
-# AllocArrays should be seen as "storage" like CuArray, not a wrapper like Transpose,
-# since we want to recurse through models and convert arrays to AllocArrays, so that
-# in the forward pass we can use our bump allocator
-Adapt.adapt_storage(::Type{<:AllocArray}, xs::AbstractArray) = AllocArray(xs)
-
-end # AdaptExt

--- a/src/AllocArrays.jl
+++ b/src/AllocArrays.jl
@@ -4,6 +4,7 @@ using ScopedValues: ScopedValue, with
 using Bumper
 using ConcurrentUtilities
 using PrecompileTools
+using Adapt
 
 # Two array types
 export AllocArray
@@ -25,6 +26,7 @@ include("AllocArray.jl")
 include("CheckedAllocArray.jl")
 include("alloc_interface.jl")
 include("autoscaling_alloc_buffer.jl")
+include("adapt.jl")
 
 const CURRENT_ALLOCATOR = ScopedValue{Allocator}(DEFAULT_ALLOCATOR)
 

--- a/src/adapt.jl
+++ b/src/adapt.jl
@@ -1,0 +1,59 @@
+# AllocArrays should be seen as "storage" like CuArray, not a wrapper like Transpose,
+# since we want to recurse through models and convert arrays to AllocArrays, so that
+# in the forward pass we can use our bump allocator
+Adapt.adapt_storage(::Type{<:AllocArray}, xs::AbstractArray) = copy_to_alloc(xs)
+
+function copy_to_alloc(xs::AbstractArray{T}) where {T}
+    arr = similar(AllocArray{T}, size(xs))
+    copyto!(arr, xs)
+    return arr
+end
+
+struct CachedUpdatelessFunction{T,F,A}
+    f::F
+    allocator::A
+end
+function CachedUpdatelessFunction{T}(f; allocator=BumperAllocator()) where {T}
+    return CachedUpdatelessFunction{T,typeof(f),typeof(allocator)}(f, allocator)
+end
+function CachedUpdatelessFunction(f; allocator=BumperAllocator())
+    return CachedUpdatelessFunction{AllocArray}(f; allocator)
+end
+
+function (c::CachedUpdatelessFunction{T})(args...; kw...) where {T}
+    with_allocator(c.allocator) do
+        try
+            tmp_f = Adapt.adapt(T, c.f)
+            args = Adapt.adapt(T, args)
+            kw = Adapt.adapt(T, kw)
+            return Adapt.adapt(Array, tmp_f(args...; kw...))
+        finally
+            reset!(c.allocator)
+        end
+    end
+end
+
+function Base.show(io::IO, mime::MIME"text/plain", c::CachedUpdatelessFunction{T}) where {T}
+    print(io, CachedUpdatelessFunction)
+    if T != AllocArray
+        print(io, "{$T}")
+    end
+    print(io, " with function\n")
+    show(io, mime, c.f)
+    print(io, "\nand allocator ")
+    show(io, mime, c.allocator)
+    return nothing
+end
+
+function Base.show(io::IO, c::CachedUpdatelessFunction{T}) where {T}
+    print(io, CachedUpdatelessFunction)
+    if T != AllocArray
+        print(io, "{$T}")
+    end
+    print(io, "(")
+    show(io, c.f)
+    print(io, ", ")
+    show(io, c.allocator)
+    print(io, ")")
+    return nothing
+end


### PR DESCRIPTION
I tried to see if AllocArrays would work with Lux/Boltz, since it seems to be working for ObjectDetector. There the only issue I had was performance problems with mixed UnsafeArrays vs matrices leading to generic matmul instead of blas. This is kinda similar to the issue from https://github.com/JuliaLang/julia/issues/57799 (though technically quite different) and I came up with a better workaround this time: we can adapt the function _within_ the `with_allocator` block to homogenize the types. As long as adapting is fast relative to the runtime, it's kinda fine.

However this means the function we evaluate does not persist, so it might not work well for ObjectDetector which updates the model struct even on the forward pass with its `W` parameter. So here I have the terrible name `CachedUpdatelessFunction`, where `Cached` is meant to mean it reuses allocations (not values), Updateless means it won't persist updates to the model, and function for a generic callable (doesn't have to be an ML model).

With this, I get

```julia
using Boltz, Lux, JLD2, AllocArrays, Adapt, Random, BenchmarkTools

model = Vision.VGG(13; pretrained=true)

model_aa = AllocArrays.CachedUpdatelessFunction(model)

batch = rand(Float32, 224, 224, 3, 20)

ps, st = Lux.setup(Random.default_rng(), model)

println("Benchmark with Array:")
display(@benchmark $model($batch, $ps, $(Lux.testmode(st))))

println("Benchmark with AllocArray:")
display(@benchmark $model_aa($batch, $ps, $(Lux.testmode(st))))
```

yielding

```julia
julia> include("script.jl");
Benchmark with Array:
BenchmarkTools.Trial: 3 samples with 1 evaluation per sample.
 Range (min … max):  1.914 s …   1.970 s  ┊ GC (min … max): 4.06% … 3.62%
 Time  (median):     1.938 s              ┊ GC (median):    3.78%
 Time  (mean ± σ):   1.940 s ± 28.213 ms  ┊ GC (mean ± σ):  3.82% ± 0.22%

  █                       █                               █  
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  1.91 s         Histogram: frequency by time        1.97 s <

 Memory estimate: 2.33 GiB, allocs estimate: 476.
Benchmark with AllocArray:
BenchmarkTools.Trial: 3 samples with 1 evaluation per sample.
 Range (min … max):  1.967 s …   1.991 s  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.977 s              ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.978 s ± 12.323 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █                      █                                █  
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  1.97 s         Histogram: frequency by time        1.99 s <

 Memory estimate: 152.69 KiB, allocs estimate: 759.
```

So we were able to eliminate GC and most allocations, though possibly with a small runtime cost. Maybe we are still not hitting some optimized path.

This feels a bit clunky/hard-to-describe currently, and moves Adapt from an extension to a regular dep, so not sure we want this but thought I'd put it up.